### PR TITLE
Dependabot should not bump Cargo.toml for every dep release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ version: 2
 updates:
   - package-ecosystem: "cargo" # See documentation for possible values
     directory: "/" # Location of package manifests
+    versioning-strategy: increase-if-necessary
     schedule:
       interval: "daily"
   - package-ecosystem: "github-actions" # See documentation for possible values

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ doc = false
 
 [dependencies]
 anyhow = "1"
-clap = { version = "4.3.21", features = ["cargo", "derive", "env", "unicode", "help", "wrap_help"] }
+clap = { version = "4.3", features = ["cargo", "derive", "env", "unicode", "help", "wrap_help"] }
 serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0.104"
 serde_repr = "0.1.16"


### PR DESCRIPTION
When used as a library, gltf-validator should accept a large range of dependencies. For example, it can probably use any version of serde 1.0, it doesn't actually require 1.0.183. But when a library specifies a patch version like 1.0.183, it forces all other projects using the library to update to 1.0.183. This is sometimes inconvenient for other people's project, there might be a bug in 1.0.182 they want to avoid.

So, only bump dependencies if you need to. This is the default for libraries but dependabot is confused because this project has a binary and a library.