### PR TITLE
Unique binary for each call to `init`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,13 @@ clap = { version = "4.3", features = ["cargo", "derive", "env", "unicode", "help
 serde = { version = "1.0.183", features = ["derive"] }
 serde_json = "1.0.104"
 serde_repr = "0.1.16"
+tempfile = "3.8.0"
 
 [build-dependencies]
 anyhow = "1"
 reqwest = { version = "0.11.18", default-features = false, features = ["blocking", "rustls-tls"] }
 tar = "0.4.39"
-tempfile = "3.7.1"
+tempfile = "3.8.0"
 xz = "0.1.0"
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,46 +205,32 @@ pub enum Transfer {
 const BINARY_BYTES: &[u8] = include_bytes!("../target/bin/gltf_validator");
 
 /// An instance of glTF validator.
+/// When GltfValidator is dropped TempPath is also dropped which will remove the binary
 pub struct GltfValidator {
-    installed_path: std::path::PathBuf,
+    installed_path: tempfile::TempPath,
 }
-
-// impl Drop for GltfValidator {
-//     fn drop(&mut self) {
-//         // Delete the binary.
-//         std::fs::remove_file(&self.installed_path).unwrap();
-//     }
-// }
 
 /// Add the `gltf_validator` binary to a temporary directory.
 /// And our path.
-fn init() -> Result<std::path::PathBuf> {
+fn init() -> Result<tempfile::TempPath> {
     use std::io::Write;
 
-    let temp_dir = std::env::temp_dir();
-
-    let installed_path = temp_dir.join("gltf_validator");
+    let mut file = tempfile::NamedTempFile::new()?;
 
     // Write the binary bytes to the file.
-    let mut file = std::fs::File::create(&installed_path)?;
     file.write_all(BINARY_BYTES)?;
-    file.sync_all()?;
 
+    let (underlying_file, installed_path) = file.into_parts();
     // Make sure the file is executable.
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        let mut perms = std::fs::metadata(&installed_path)?.permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&installed_path, perms)?;
+        let perms = std::fs::Permissions::from_mode(0o755);
+        underlying_file.set_permissions(perms)?;
     }
 
-    let existing_path_var = std::env::var_os("PATH").unwrap_or_default();
-    let existing_paths = std::env::split_paths(&existing_path_var);
-    std::env::set_var(
-        "PATH",
-        std::env::join_paths(existing_paths.chain(std::iter::once(installed_path.clone())))?,
-    );
+    // Sync to make sure it all exists
+    underlying_file.sync_all()?;
 
     Ok(installed_path)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,7 +228,7 @@ fn init() -> Result<std::path::PathBuf> {
     // Write the binary bytes to the file.
     let mut file = std::fs::File::create(&installed_path)?;
     file.write_all(BINARY_BYTES)?;
-    file.flush()?;
+    file.sync_all()?;
 
     // Make sure the file is executable.
     #[cfg(unix)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -209,12 +209,12 @@ pub struct GltfValidator {
     installed_path: std::path::PathBuf,
 }
 
-impl Drop for GltfValidator {
-    fn drop(&mut self) {
-        // Delete the binary.
-        std::fs::remove_file(&self.installed_path).unwrap();
-    }
-}
+// impl Drop for GltfValidator {
+//     fn drop(&mut self) {
+//         // Delete the binary.
+//         std::fs::remove_file(&self.installed_path).unwrap();
+//     }
+// }
 
 /// Add the `gltf_validator` binary to a temporary directory.
 /// And our path.


### PR DESCRIPTION
This uses a NamedTempFile that has its own drop impl to delete the file when it goes out of scope. This should also mean that each call to `init()` creates a unique copy of the bin for that evaluation. So, we shouldn't see any two processes/threads competing to use the same executable.